### PR TITLE
Fix problem with newer kea versions, where "loggers" cannot be explicitly "null"

### DIFF
--- a/config.go
+++ b/config.go
@@ -73,7 +73,7 @@ type Dhcp4 struct {
 	HostReservationIdentifiers []string                `json:"host-reservation-identifiers"`
 	InterfacesConfig           InterfacesConfig        `json:"interfaces-config"`
 	LeaseDatabase              LeaseDatabase           `json:"lease-database"`
-	Loggers                    []Loggers               `json:"loggers"`
+	Loggers                    []Loggers               `json:"loggers,omitempty"`
 	MatchClientId              bool                    `json:"match-client-id"`
 	NextServer                 string                  `json:"next-server"`
 	OptionData                 []OptionData            `json:"option-data"`


### PR DESCRIPTION
omit empty loggers attribute to prevent server error